### PR TITLE
lib: memcpy: modify memcpy to copy 8-byte chunks instead of 16-byte

### DIFF
--- a/lib/string.c
+++ b/lib/string.c
@@ -33,7 +33,7 @@ void *memcpy(void *dst, const void *src, int cnt)
 	char *d;
 	const char *s;
 	struct chunk {
-		unsigned long long val[2];
+		unsigned long val[2];
 	};
 
 	const struct chunk *csrc = (const struct chunk *) src;


### PR DESCRIPTION
On some target cores and with some GCC compilers, on the line *cdst++ = *csrc++;
the compiler will emit a memcpy because the size of 16 bytes is too big to emit standard reg read/store .
Emitting a memcpy in the memcpy function will create a recursive loop that will overflow the stack.
Noticed that the 8 byte copy works on all current targets. Thus changed the struct to have just unsigned long type variable.

Fixes: dd4da885b892 ("lib: memcpy: modify memcpy to copy 16-byte chunks of memory")

[nicolas.ferre@microchip.com: backport to 3.x branch]